### PR TITLE
feat: Pre-build islands

### DIFF
--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -1,151 +1,145 @@
-import { BuildOptions } from "https://deno.land/x/esbuild@v0.17.11/mod.js";
+import {
+  BuildOptions,
+  BuildResult,
+} from "https://deno.land/x/esbuild@v0.17.11/mod.js";
 import { BUILD_ID } from "./constants.ts";
-import { denoPlugin, esbuild, toFileUrl } from "./deps.ts";
+import { denoPlugin, esbuild, join, toFileUrl } from "./deps.ts";
 import { Island, Plugin } from "./types.ts";
+import { BlobStorage, fsStorage, inMemoryStorage } from "./storage.ts";
 
 export interface JSXConfig {
   jsx: "react" | "react-jsx";
   jsxImportSource?: string;
 }
 
-let esbuildInitialized: boolean | Promise<void> = false;
-async function ensureEsbuildInitialized() {
-  if (esbuildInitialized === false) {
-    // deno-lint-ignore no-deprecated-deno-api
-    if (Deno.run === undefined) {
-      const wasmURL = new URL("./esbuild_v0.17.11.wasm", import.meta.url).href;
-      esbuildInitialized = fetch(wasmURL).then(async (r) => {
-        const resp = new Response(r.body, {
-          headers: { "Content-Type": "application/wasm" },
-        });
-        const wasmModule = await WebAssembly.compileStreaming(resp);
-        await esbuild.initialize({
-          wasmModule,
-          worker: false,
-        });
-      });
-    } else {
-      esbuild.initialize({});
-    }
-    await esbuildInitialized;
-    esbuildInitialized = true;
-  } else if (esbuildInitialized instanceof Promise) {
-    await esbuildInitialized;
+let esBuildInitPromise: Promise<void> | undefined = undefined;
+const ensureEsbuildInitialized = () => {
+  if (!esBuildInitPromise) {
+    const onDenoDeploy = Deno.run === undefined;
+
+    esBuildInitPromise = onDenoDeploy
+      ? fetch(new URL("./esbuild_v0.17.11.wasm", import.meta.url))
+        .then((r) =>
+          WebAssembly.compileStreaming(
+            new Response(r.body, {
+              headers: { "Content-Type": "application/wasm" },
+            }),
+          )
+        )
+        .then((wasmModule) => esbuild.initialize({ wasmModule, worker: false }))
+      : esbuild.initialize({});
   }
-}
+
+  return esBuildInitPromise;
+};
 
 const JSX_RUNTIME_MODE = {
   "react": "transform",
   "react-jsx": "automatic",
 } as const;
 
-export class Bundler {
-  #importMapURL: URL;
-  #jsxConfig: JSXConfig;
-  #islands: Island[];
-  #plugins: Plugin[];
-  #cache: Map<string, Uint8Array> | Promise<void> | undefined = undefined;
-  #dev: boolean;
+interface Options {
+  importMapURL: URL;
+  jsxConfig: JSXConfig;
+  islands: Island[];
+  plugins: Plugin[];
+  dev: boolean;
+  absWorkingDir: string;
+}
 
-  constructor(
-    islands: Island[],
-    plugins: Plugin[],
-    importMapURL: URL,
-    jsxConfig: JSXConfig,
-    dev: boolean,
-  ) {
-    this.#islands = islands;
-    this.#plugins = plugins;
-    this.#importMapURL = importMapURL;
-    this.#jsxConfig = jsxConfig;
-    this.#dev = dev;
+const bundle = async (
+  { importMapURL, dev, islands, plugins, jsxConfig, absWorkingDir }: Options,
+) => {
+  const entryPoints: Record<string, string> = {
+    main: dev
+      ? new URL("../../src/runtime/main_dev.ts", import.meta.url).href
+      : new URL("../../src/runtime/main.ts", import.meta.url).href,
+  };
+
+  for (const island of islands) {
+    entryPoints[`island-${island.id}`] = island.url;
   }
 
-  async bundle() {
-    const entryPoints: Record<string, string> = {
-      main: this.#dev
-        ? new URL("../../src/runtime/main_dev.ts", import.meta.url).href
-        : new URL("../../src/runtime/main.ts", import.meta.url).href,
-    };
-
-    for (const island of this.#islands) {
-      entryPoints[`island-${island.id}`] = island.url;
+  for (const plugin of plugins) {
+    for (const [name, url] of Object.entries(plugin.entrypoints ?? {})) {
+      entryPoints[`plugin-${plugin.name}-${name}`] = url;
     }
+  }
 
-    for (const plugin of this.#plugins) {
-      for (const [name, url] of Object.entries(plugin.entrypoints ?? {})) {
-        entryPoints[`plugin-${plugin.name}-${name}`] = url;
-      }
-    }
+  await ensureEsbuildInitialized();
+  // In dev-mode we skip identifier minification to be able to show proper
+  // component names in Preact DevTools instead of single characters.
+  const minifyOptions: Partial<BuildOptions> = dev
+    ? { minifyIdentifiers: false, minifySyntax: true, minifyWhitespace: true }
+    : { minify: true };
+  const bundle = await esbuild.build({
+    bundle: true,
+    define: { __FRSH_BUILD_ID: `"${BUILD_ID}"` },
+    entryPoints,
+    format: "esm",
+    metafile: true,
+    ...minifyOptions,
+    outdir: ".",
+    // This is requried to ensure the format of the outputFiles path is the same
+    // between windows and linux
+    absWorkingDir,
+    outfile: "",
+    platform: "neutral",
+    plugins: [denoPlugin({ importMapURL: importMapURL })],
+    sourcemap: dev ? "linked" : false,
+    splitting: true,
+    target: ["chrome99", "firefox99", "safari11", "safari15"],
+    treeShaking: true,
+    write: false,
+    jsx: JSX_RUNTIME_MODE[jsxConfig.jsx],
+    jsxImportSource: jsxConfig.jsxImportSource,
+  });
 
-    const absWorkingDir = Deno.cwd();
-    await ensureEsbuildInitialized();
-    // In dev-mode we skip identifier minification to be able to show proper
-    // component names in Preact DevTools instead of single characters.
-    const minifyOptions: Partial<BuildOptions> = this.#dev
-      ? { minifyIdentifiers: false, minifySyntax: true, minifyWhitespace: true }
-      : { minify: true };
-    const bundle = await esbuild.build({
-      bundle: true,
-      define: { __FRSH_BUILD_ID: `"${BUILD_ID}"` },
-      entryPoints,
-      format: "esm",
-      metafile: true,
-      ...minifyOptions,
-      outdir: ".",
-      // This is requried to ensure the format of the outputFiles path is the same
-      // between windows and linux
-      absWorkingDir,
-      outfile: "",
-      platform: "neutral",
-      plugins: [denoPlugin({ importMapURL: this.#importMapURL })],
-      sourcemap: this.#dev ? "linked" : false,
-      splitting: true,
-      target: ["chrome99", "firefox99", "safari11", "safari15"],
-      treeShaking: true,
-      write: false,
-      jsx: JSX_RUNTIME_MODE[this.#jsxConfig.jsx],
-      jsxImportSource: this.#jsxConfig.jsxImportSource,
-    });
-    // const metafileOutputs = bundle.metafile!.outputs;
+  return bundle;
+};
 
-    // for (const path in metafileOutputs) {
-    //   const meta = metafileOutputs[path];
-    //   const imports = meta.imports
-    //     .filter(({ kind }) => kind === "import-statement")
-    //     .map(({ path }) => `/${path}`);
-    //   this.#preloads.set(`/${path}`, imports);
-    // }
+const storeBundle = async (
+  bundle: BuildResult,
+  storage: BlobStorage,
+  absWorkingDir: string,
+) => {
+  await storage.clear();
 
-    const cache = new Map<string, Uint8Array>();
-    const absDirUrlLength = toFileUrl(absWorkingDir).href.length;
-    for (const file of bundle.outputFiles) {
-      cache.set(
+  const absDirUrlLength = toFileUrl(absWorkingDir).href.length;
+
+  await Promise.all([
+    bundle.outputFiles?.map((file) =>
+      storage.set(
         toFileUrl(file.path).href.substring(absDirUrlLength),
         file.contents,
-      );
-    }
-    this.#cache = cache;
+      )
+    ),
+  ]);
+};
 
-    return;
+export const createBundle = async (
+  options: Omit<Options, "absWorkingDir">,
+): Promise<BlobStorage> => {
+  const absWorkingDir = Deno.cwd();
+  const storagePath = join(absWorkingDir, "/.frsh");
+
+  if (options.dev) {
+    const fs = await fsStorage(storagePath);
+    const inMemory = inMemoryStorage();
+
+    const [prod, dev] = await Promise.all([
+      bundle({ ...options, dev: false, absWorkingDir }),
+      bundle({ ...options, dev: true, absWorkingDir }),
+    ]);
+
+    await Promise.all([
+      storeBundle(prod, fs, absWorkingDir),
+      storeBundle(dev, inMemory, absWorkingDir),
+    ]);
+
+    return inMemory;
+  } else {
+    return fsStorage(storagePath);
   }
-
-  async cache(): Promise<Map<string, Uint8Array>> {
-    if (this.#cache === undefined) {
-      this.#cache = this.bundle();
-    }
-    if (this.#cache instanceof Promise) {
-      await this.#cache;
-    }
-    return this.#cache as Map<string, Uint8Array>;
-  }
-
-  async get(path: string): Promise<Uint8Array | null> {
-    const cache = await this.cache();
-    return cache.get(path) ?? null;
-  }
-
-  // getPreloads(path: string): string[] {
-  //   return this.#preloads.get(path) ?? [];
-  // }
-}
+};
+  

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -73,7 +73,7 @@ const bundle = async (
     define: { __FRSH_BUILD_ID: `"${BUILD_ID}"` },
     entryPoints,
     format: "esm",
-    metafile: true,
+    metafile: !dev,
     ...minifyOptions,
     outdir: ".",
     // This is requried to ensure the format of the outputFiles path is the same
@@ -108,6 +108,13 @@ const storeBundle = async (
   absWorkingDir: string,
 ) => {
   await storage.clear();
+
+  if (bundle.metafile) {
+    await storage.set(
+      "metafile.json",
+      new TextEncoder().encode(JSON.stringify(bundle.metafile)),
+    );
+  }
 
   const absDirUrlLength = toFileUrl(absWorkingDir).href.length;
 

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -122,9 +122,9 @@ export const createBundle = async (
 ): Promise<BlobStorage> => {
   const absWorkingDir = Deno.cwd();
   const storagePath = join(absWorkingDir, "/.frsh");
+  const fs = await fsStorage(storagePath);
 
   if (options.dev) {
-    const fs = await fsStorage(storagePath);
     const inMemory = inMemoryStorage();
 
     const [prod, dev] = await Promise.all([
@@ -138,8 +138,8 @@ export const createBundle = async (
     ]);
 
     return inMemory;
-  } else {
-    return fsStorage(storagePath);
   }
+
+  return fs;
 };
   

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -153,4 +153,3 @@ export const createBundle = async (
 
   return fs;
 };
-  

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -11,7 +11,7 @@ import {
 import { h } from "preact";
 import * as router from "./router.ts";
 import { Manifest } from "./mod.ts";
-import { Bundler, JSXConfig } from "./bundle.ts";
+import { createBundle, JSXConfig } from "./bundle.ts";
 import { ALIVE_URL, BUILD_ID, JS_PREFIX, REFRESH_JS_URL } from "./constants.ts";
 import DefaultErrorHandler from "./default_error_page.ts";
 import {
@@ -35,6 +35,8 @@ import {
 import { render as internalRender } from "./render.ts";
 import { ContentSecurityPolicyDirectives, SELF } from "../runtime/csp.ts";
 import { ASSET_CACHE_BUST_KEY, INTERNAL_PREFIX } from "../runtime/utils.ts";
+import { BlobStorage } from "./storage.ts";
+
 interface RouterState {
   state: Record<string, unknown>;
 }
@@ -57,13 +59,13 @@ export class ServerContext {
   #routes: Route[];
   #islands: Island[];
   #staticFiles: StaticFile[];
-  #bundler: Bundler;
   #renderFn: RenderFunction;
   #middlewares: MiddlewareRoute[];
   #app: AppModule;
   #notFound: UnknownPage;
   #error: ErrorPage;
   #plugins: Plugin[];
+  #bundle: Promise<BlobStorage>;
 
   constructor(
     routes: Route[],
@@ -88,13 +90,13 @@ export class ServerContext {
     this.#error = error;
     this.#plugins = plugins;
     this.#dev = typeof Deno.env.get("DENO_DEPLOYMENT_ID") !== "string"; // Env var is only set in prod (on Deploy).
-    this.#bundler = new Bundler(
-      this.#islands,
-      this.#plugins,
+    this.#bundle = createBundle({
+      islands: this.#islands,
+      plugins: this.#plugins,
       importMapURL,
       jsxConfig,
-      this.#dev,
-    );
+      dev: this.#dev,
+    });
   }
 
   /**
@@ -653,7 +655,8 @@ export class ServerContext {
   #bundleAssetRoute = (): router.MatchHandler => {
     return async (_req, _ctx, params) => {
       const path = `/${params.path}`;
-      const file = await this.#bundler.get(path);
+      const storage = await this.#bundle;
+      const file = await storage.get(path);
       let res;
       if (file) {
         const headers = new Headers({

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -1,10 +1,11 @@
 // -- std --
 export {
+  join,
   extname,
   fromFileUrl,
   toFileUrl,
 } from "https://deno.land/std@0.178.0/path/mod.ts";
-export { walk } from "https://deno.land/std@0.178.0/fs/walk.ts";
+export { walk, ensureDir, emptyDir } from "https://deno.land/std@0.178.0/fs/mod.ts";
 export { serve } from "https://deno.land/std@0.178.0/http/server.ts";
 export type {
   ConnInfo,

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -10,7 +10,7 @@ export {
   ensureDir,
   walk,
 } from "https://deno.land/std@0.178.0/fs/mod.ts";
-export * as colors from "https://deno.land/std@0.178.0/fmt/colors.ts"
+export * as colors from "https://deno.land/std@0.178.0/fmt/colors.ts";
 export { serve } from "https://deno.land/std@0.178.0/http/server.ts";
 export type {
   ConnInfo,

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -1,11 +1,16 @@
 // -- std --
 export {
-  join,
   extname,
   fromFileUrl,
+  join,
   toFileUrl,
 } from "https://deno.land/std@0.178.0/path/mod.ts";
-export { walk, ensureDir, emptyDir } from "https://deno.land/std@0.178.0/fs/mod.ts";
+export {
+  emptyDir,
+  ensureDir,
+  walk,
+} from "https://deno.land/std@0.178.0/fs/mod.ts";
+export * as colors from "https://deno.land/std@0.178.0/fmt/colors.ts"
 export { serve } from "https://deno.land/std@0.178.0/http/server.ts";
 export type {
   ConnInfo,
@@ -19,15 +24,11 @@ export {
 export { toHashString } from "https://deno.land/std@0.178.0/crypto/to_hash_string.ts";
 
 // -- esbuild --
-// @deno-types="https://deno.land/x/esbuild@v0.17.11/mod.d.ts"
-import * as esbuildWasm from "https://deno.land/x/esbuild@v0.17.11/wasm.js";
-import * as esbuildNative from "https://deno.land/x/esbuild@v0.17.11/mod.js";
-// @ts-ignore trust me
-// deno-lint-ignore no-deprecated-deno-api
-const esbuild: typeof esbuildWasm = Deno.run === undefined
-  ? esbuildWasm
-  : esbuildNative;
-export { esbuild, esbuildWasm as esbuildTypes };
+export * as esbuild from "https://deno.land/x/esbuild@v0.17.11/mod.js";
+export type {
+  BuildOptions,
+  BuildResult,
+} from "https://deno.land/x/esbuild@v0.17.11/mod.js";
 
 // TODO(lino-levan): Replace with versioned import
 export { denoPlugin } from "https://raw.githubusercontent.com/lucacasonato/esbuild_deno_loader/8031f71afa1bbcd3237a94b11f53a2e5c5c0e7bf/mod.ts";

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -271,7 +271,8 @@ export async function render<Data>(
       script += `import ${island.name} from "${url}";`;
       islandRegistry += `${island.id}:${island.name},`;
     }
-    script += `try { revive({${islandRegistry}}, STATE[0]); } catch(err) { console.log("revive err", err);throw err; };`;
+    script +=
+      `try { revive({${islandRegistry}}, STATE[0]); } catch(err) { console.log("revive err", err);throw err; };`;
   }
 
   if (state[0].length > 0 || state[1].length > 0) {

--- a/src/server/storage.ts
+++ b/src/server/storage.ts
@@ -1,0 +1,31 @@
+// deno-lint-ignore-file require-await
+import { emptyDir, ensureDir, join } from "./deps.ts";
+
+export interface BlobStorage {
+  set: (key: string, value: Uint8Array) => Promise<void>;
+  get: (key: string) => Promise<Uint8Array | undefined>;
+  clear: () => Promise<void>;
+}
+
+export const inMemoryStorage = (): BlobStorage => {
+  const map = new Map();
+
+  return {
+    clear: async () => map.clear(),
+    get: async (k: string) => map.get(k),
+    set: async (k: string, v: Uint8Array) => {
+      map.set(k, v);
+    },
+  };
+};
+
+export const fsStorage = async (rootDir: string): Promise<BlobStorage> => {
+  await ensureDir(rootDir);
+
+  return {
+    clear: () => emptyDir(rootDir),
+    get: (k: string) => Deno.readFile(join(rootDir, k)),
+    set: (k: string, v: Uint8Array) =>
+      Deno.writeFile(join(rootDir, k), v, { create: true, append: false }),
+  };
+};

--- a/src/server/storage.ts
+++ b/src/server/storage.ts
@@ -3,7 +3,9 @@ import { emptyDir, ensureDir, join } from "./deps.ts";
 
 export interface BlobStorage {
   set: (key: string, value: Uint8Array) => Promise<void>;
-  get: (key: string) => Promise<Uint8Array | undefined>;
+  get: (
+    key: string,
+  ) => Promise<Uint8Array | ReadableStream<Uint8Array> | undefined>;
   clear: () => Promise<void>;
 }
 
@@ -26,10 +28,10 @@ export const fsStorage = async (rootDir: string): Promise<BlobStorage> => {
     clear: () => emptyDir(rootDir),
     get: async (k: string) => {
       console.time(`storage: ${k}`);
-      const blob = await Deno.readFile(join(rootDir, k));
+      const file = await Deno.open(join(rootDir, k), { read: true });
       console.timeEnd(`storage: ${k}`);
 
-      return blob;
+      return file.readable;
     },
     set: (k: string, v: Uint8Array) =>
       Deno.writeFile(join(rootDir, k), v, { create: true, append: false }),

--- a/src/server/storage.ts
+++ b/src/server/storage.ts
@@ -24,7 +24,13 @@ export const fsStorage = async (rootDir: string): Promise<BlobStorage> => {
 
   return {
     clear: () => emptyDir(rootDir),
-    get: (k: string) => Deno.readFile(join(rootDir, k)),
+    get: async (k: string) => {
+      console.time(`storage: ${k}`);
+      const blob = await Deno.readFile(join(rootDir, k));
+      console.timeEnd(`storage: ${k}`);
+
+      return blob;
+    },
     set: (k: string, v: Uint8Array) =>
       Deno.writeFile(join(rootDir, k), v, { create: true, append: false }),
   };

--- a/src/server/storage.ts
+++ b/src/server/storage.ts
@@ -27,10 +27,7 @@ export const fsStorage = async (rootDir: string): Promise<BlobStorage> => {
   return {
     clear: () => emptyDir(rootDir),
     get: async (k: string) => {
-      console.time(`storage: ${k}`);
       const file = await Deno.open(join(rootDir, k), { read: true });
-      console.timeEnd(`storage: ${k}`);
-
       return file.readable;
     },
     set: (k: string, v: Uint8Array) =>


### PR DESCRIPTION
## What's the purpose of this PR?
This PR pre-bundles islands so we don't need to spend time processing them on the edge. 

## How does it work?
When running locally (on the developers machine) we run esbuild twice. One for the development bundle and another one for the production bundle. We then, store the production bundle assets into a folder at `${Deno.cwd()}/.frsh`. The developer then commits the `.frsh` folder and `git push`. On deno deploy, we use the pre-built production bundles and serve them as static files. 

## Why am I doing these changes?
Bundling can take a long time on huge projects. We have some projects where bundling takes as long as 5s on Deno Deploy. We tried a CloudFlare + Deno Deploy combo but from time to time (and always on a new deploy of our website) a request for an asset(JS) falls on Deno Deploy and the app really slows down. 

Hopefully, more people are having the same issue in here: https://github.com/denoland/fresh/issues/1062 and some people even tried to contribute back to fresh: https://github.com/denoland/fresh/pull/1084.

## Addons
I'm also outputing the metafile so we can use tools like https://esbuild.github.io/analyze/