### PR TITLE
feat: use Deno KV for storing fresh assets

### DIFF
--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -202,6 +202,7 @@ const createKv = () => {
   const chunksize = 65536;
   const namespace = ["_frsh", "js", BUILD_ID];
 
+  // @ts-ignore as `Deno.openKv` is still unstable.
   const kvPromise = Deno.openKv?.();
 
   if (!kvPromise) return null;

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -2,90 +2,84 @@ import { BuildOptions } from "https://deno.land/x/esbuild@v0.17.11/mod.js";
 import { BUILD_ID } from "./constants.ts";
 import { denoPlugin, esbuild, toFileUrl } from "./deps.ts";
 import { Island, Plugin } from "./types.ts";
+import { once } from "./once.ts";
 
 export interface JSXConfig {
   jsx: "react" | "react-jsx";
   jsxImportSource?: string;
 }
 
-let esbuildInitialized: boolean | Promise<void> = false;
-async function ensureEsbuildInitialized() {
-  if (esbuildInitialized === false) {
-    // deno-lint-ignore no-deprecated-deno-api
-    if (Deno.run === undefined) {
-      const wasmURL = new URL("./esbuild_v0.17.11.wasm", import.meta.url).href;
-      esbuildInitialized = fetch(wasmURL).then(async (r) => {
-        const resp = new Response(r.body, {
-          headers: { "Content-Type": "application/wasm" },
-        });
-        const wasmModule = await WebAssembly.compileStreaming(resp);
-        await esbuild.initialize({
-          wasmModule,
-          worker: false,
-        });
-      });
-    } else {
-      esbuild.initialize({});
-    }
-    await esbuildInitialized;
-    esbuildInitialized = true;
-  } else if (esbuildInitialized instanceof Promise) {
-    await esbuildInitialized;
+const initESBuild = once(async () => {
+  // deno-lint-ignore no-deprecated-deno-api
+  if (typeof Deno.run !== "undefined") {
+    await esbuild.initialize({});
+
+    return;
   }
-}
+
+  // On Deno Deploy, let's use WASM!
+  const wasmURL = new URL("./esbuild_v0.17.11.wasm", import.meta.url).href;
+  const { body } = await fetch(wasmURL);
+  const wasmModule = await WebAssembly.compileStreaming(
+    new Response(body, {
+      headers: { "Content-Type": "application/wasm" },
+    }),
+  );
+  await esbuild.initialize({ wasmModule, worker: false });
+});
 
 const JSX_RUNTIME_MODE = {
   "react": "transform",
   "react-jsx": "automatic",
 } as const;
 
-export class Bundler {
-  #importMapURL: URL;
-  #jsxConfig: JSXConfig;
-  #islands: Island[];
-  #plugins: Plugin[];
-  #cache: Map<string, Uint8Array> | Promise<void> | undefined = undefined;
-  #dev: boolean;
+interface Options {
+  islands: Island[];
+  plugins: Plugin[];
+  importMapURL: URL;
+  jsxConfig: JSXConfig;
+  dev: boolean;
+}
 
-  constructor(
-    islands: Island[],
-    plugins: Plugin[],
-    importMapURL: URL,
-    jsxConfig: JSXConfig,
-    dev: boolean,
-  ) {
-    this.#islands = islands;
-    this.#plugins = plugins;
-    this.#importMapURL = importMapURL;
-    this.#jsxConfig = jsxConfig;
-    this.#dev = dev;
-  }
+const absWorkingDir = Deno.cwd();
 
-  async bundle() {
+const createBundler = ({
+  islands,
+  plugins,
+  importMapURL,
+  jsxConfig,
+  dev,
+}: Options) => {
+  const esbuildInit = initESBuild();
+
+  return async () => {
+    const start = performance.now();
+
     const entryPoints: Record<string, string> = {
-      main: this.#dev
+      main: dev
         ? new URL("../../src/runtime/main_dev.ts", import.meta.url).href
         : new URL("../../src/runtime/main.ts", import.meta.url).href,
     };
 
-    for (const island of this.#islands) {
+    for (const island of islands) {
       entryPoints[`island-${island.id}`] = island.url;
     }
 
-    for (const plugin of this.#plugins) {
+    for (const plugin of plugins) {
       for (const [name, url] of Object.entries(plugin.entrypoints ?? {})) {
         entryPoints[`plugin-${plugin.name}-${name}`] = url;
       }
     }
 
-    const absWorkingDir = Deno.cwd();
-    await ensureEsbuildInitialized();
+    await esbuildInit;
+
     // In dev-mode we skip identifier minification to be able to show proper
     // component names in Preact DevTools instead of single characters.
-    const minifyOptions: Partial<BuildOptions> = this.#dev
+    const minifyOptions: Partial<BuildOptions> = dev
       ? { minifyIdentifiers: false, minifySyntax: true, minifyWhitespace: true }
       : { minify: true };
-    const bundle = await esbuild.build({
+
+    const build = await esbuild.build({
       bundle: true,
       define: { __FRSH_BUILD_ID: `"${BUILD_ID}"` },
       entryPoints,
@@ -98,58 +92,169 @@ export class Bundler {
       absWorkingDir,
       outfile: "",
       platform: "neutral",
-      plugins: [denoPlugin({ importMapURL: this.#importMapURL })],
-      sourcemap: this.#dev ? "linked" : false,
+      plugins: [denoPlugin({ importMapURL: importMapURL })],
+      sourcemap: dev ? "linked" : false,
       splitting: true,
       target: ["chrome99", "firefox99", "safari15"],
       treeShaking: true,
       write: false,
-      jsx: JSX_RUNTIME_MODE[this.#jsxConfig.jsx],
-      jsxImportSource: this.#jsxConfig.jsxImportSource,
+      jsx: JSX_RUNTIME_MODE[jsxConfig.jsx],
+      jsxImportSource: jsxConfig.jsxImportSource,
     });
-    // const metafileOutputs = bundle.metafile!.outputs;
 
-    // for (const path in metafileOutputs) {
-    //   const meta = metafileOutputs[path];
-    //   const imports = meta.imports
-    //     .filter(({ kind }) => kind === "import-statement")
-    //     .map(({ path }) => `/${path}`);
-    //   this.#preloads.set(`/${path}`, imports);
-    // }
+    console.info(
+      `📦 Bundling took ${((performance.now() - start) / 1e3).toFixed(2)}s`,
+    );
 
-    const cache = new Map<string, Uint8Array>();
+    return build;
+  };
+};
+
+export const createAssetsStorage = (options: Options) => {
+  const kv = createKv();
+  const bundler = createBundler(options);
+
+  // inMemoryCache used in case of failure of Deno.KV or bundle not found
+  const inMemoryCache = new Map<string, Uint8Array>();
+
+  const saveBundleOnKv = async () => {
+    const start = performance.now();
+
+    // We need to save chunks first, islands/plugins last so we address esm.sh build instabilities
+    const isChunk = /\/chunk-[a-zA-Z0-9]*.js/;
+    const chunksFirst = [...inMemoryCache.keys()].sort((a, b) => {
+      const aIsChunk = isChunk.test(a);
+      const bIsChunk = isChunk.test(b);
+      const cmp = a > b ? 1 : a < b ? -1 : 0;
+      return aIsChunk && bIsChunk ? cmp : aIsChunk ? -10 : bIsChunk ? 10 : cmp;
+    });
+
+    for (const file of chunksFirst) {
+      const content = inMemoryCache.get(file)!;
+      await kv?.saveFile(file, content).catch((e) =>
+        console.error(`Error: Saving file to KV failed ${file}\n`, e)
+      );
+    }
+
+    console.info(
+      `💾 Saving bundle to Deno.KV took ${
+        ((performance.now() - start) / 1e3).toFixed(2)
+      }s`,
+    );
+  };
+
+  const clearOldData = async () => {
+    const start = performance.now();
+    await kv?.housekeep();
+    console.info(
+      `🧹 Housekeeping stale data on Deno.KV took ${
+        ((performance.now() - start) / 1e3).toFixed(2)
+      }s`,
+    );
+  };
+
+  const bundleAndCacheOnce = once(async () => {
+    const build = await bundler();
+
+    // Save Build on inMemoryCache
     const absDirUrlLength = toFileUrl(absWorkingDir).href.length;
-    for (const file of bundle.outputFiles) {
-      cache.set(
+    for (const file of build.outputFiles!) {
+      inMemoryCache.set(
         toFileUrl(file.path).href.substring(absDirUrlLength),
         file.contents,
       );
     }
-    cache.set(
+    inMemoryCache.set(
       "/metafile.json",
-      new TextEncoder().encode(JSON.stringify(bundle.metafile)),
+      new TextEncoder().encode(JSON.stringify(build.metafile)),
     );
-    this.#cache = cache;
 
-    return;
-  }
+    // Fire & forget saving on KV & housekeeping
+    kv && saveBundleOnKv().then(clearOldData).catch((e) => console.error(e));
+  });
 
-  async cache(): Promise<Map<string, Uint8Array>> {
-    if (this.#cache === undefined) {
-      this.#cache = this.bundle();
-    }
-    if (this.#cache instanceof Promise) {
-      await this.#cache;
-    }
-    return this.#cache as Map<string, Uint8Array>;
-  }
+  return {
+    get: async (path: string) => {
+      const file = inMemoryCache.get(path) ||
+        await kv?.getFile(path).catch(() => null);
 
-  async get(path: string): Promise<Uint8Array | null> {
-    const cache = await this.cache();
-    return cache.get(path) ?? null;
-  }
+      if (file instanceof ReadableStream) {
+        console.info(`🚤 streaming directly from Deno.KV: ${path}`);
+      }
 
-  // getPreloads(path: string): string[] {
-  //   return this.#preloads.get(path) ?? [];
-  // }
-}
+      if (file) return file;
+
+      // Cache not found on both Kv or inMemory, let's build and cache it
+      await bundleAndCacheOnce();
+
+      return inMemoryCache.get(path);
+    },
+  };
+};
+
+type PromiseOrValue<T> = T extends Promise<infer K> ? K : T;
+
+export type AssetsStorage = PromiseOrValue<
+  ReturnType<typeof createAssetsStorage>
+>;
+
+const createKv = () => {
+  const chunksize = 65536;
+  const namespace = ["_frsh", "js", BUILD_ID];
+
+  const kvPromise = Deno.openKv?.();
+
+  if (!kvPromise) return null;
+
+  return {
+    getFile: async (file: string) => {
+      const kv = await kvPromise;
+      const filepath = [...namespace, file];
+      const metadata = await kv.get(filepath);
+
+      if (metadata.versionstamp === null) {
+        return null;
+      }
+
+      return new ReadableStream<Uint8Array>({
+        start: async (sink) => {
+          for await (const chunk of kv.list({ prefix: filepath })) {
+            sink.enqueue(chunk.value as Uint8Array);
+          }
+          sink.close();
+        },
+      });
+    },
+    saveFile: async (file: string, content: Uint8Array) => {
+      const kv = await kvPromise;
+      const filepath = [...namespace, file];
+      const metadata = await kv.get(filepath);
+
+      let transaction = kv.atomic();
+      let chunks = 0;
+      for (; chunks * chunksize < content.length; chunks++) {
+        transaction = transaction.set(
+          [...filepath, chunks],
+          content.slice(chunks * chunksize, (chunks + 1) * chunksize),
+        );
+      }
+      const result = await transaction
+        .set(filepath, chunks)
+        .check(metadata)
+        .commit();
+
+      return result.ok;
+    },
+    housekeep: async () => {
+      const kv = await kvPromise;
+
+      for await (
+        const item of kv.list({ prefix: ["_frsh", "js"] })
+      ) {
+        if (item.key.includes(BUILD_ID)) continue;
+
+        await kv.delete(item.key);
+      }
+    },
+  };
+};

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -231,6 +231,7 @@ const createKv = () => {
       const filepath = [...namespace, file];
       const metadata = await kv.get(filepath);
 
+// Current limitation: As of May 2023, KV Transactions only support a maximum of 10 operations.
       let transaction = kv.atomic();
       let chunks = 0;
       for (; chunks * chunksize < content.length; chunks++) {

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -11,7 +11,7 @@ import {
 import { h } from "preact";
 import * as router from "./router.ts";
 import { Manifest } from "./mod.ts";
-import { Bundler, JSXConfig } from "./bundle.ts";
+import { AssetsStorage, createAssetsStorage, JSXConfig } from "./bundle.ts";
 import { ALIVE_URL, BUILD_ID, JS_PREFIX, REFRESH_JS_URL } from "./constants.ts";
 import DefaultErrorHandler from "./default_error_page.ts";
 import {
@@ -57,7 +57,7 @@ export class ServerContext {
   #routes: Route[];
   #islands: Island[];
   #staticFiles: StaticFile[];
-  #bundler: Bundler;
+  #assets: AssetsStorage;
   #renderFn: RenderFunction;
   #middlewares: MiddlewareRoute[];
   #app: AppModule;
@@ -88,13 +88,13 @@ export class ServerContext {
     this.#error = error;
     this.#plugins = plugins;
     this.#dev = typeof Deno.env.get("DENO_DEPLOYMENT_ID") !== "string"; // Env var is only set in prod (on Deploy).
-    this.#bundler = new Bundler(
-      this.#islands,
-      this.#plugins,
+    this.#assets = createAssetsStorage({
+      islands: this.#islands,
+      plugins: this.#plugins,
       importMapURL,
       jsxConfig,
-      this.#dev,
-    );
+      dev: this.#dev,
+    });
   }
 
   /**
@@ -655,7 +655,7 @@ export class ServerContext {
   #bundleAssetRoute = (): router.MatchHandler => {
     return async (_req, _ctx, params) => {
       const path = `/${params.path}`;
-      const file = await this.#bundler.get(path);
+      const file = await this.#assets.get(path);
       let res;
       if (file) {
         const headers = new Headers({

--- a/src/server/once.ts
+++ b/src/server/once.ts
@@ -1,0 +1,8 @@
+export function once<R>(fn: () => R): () => R {
+  let main = () => {
+    const value = fn();
+    main = () => value;
+    return value;
+  };
+  return () => main();
+}


### PR DESCRIPTION
This PR adds esbuild assets to Deno KV. This feature uses Deno KV as an optimization and KV is not required for serving assets on both dev and production environments. 

## How does it work?
All isolate instances have an internal inMemory cache. We use the following algorithm for incoming requests:
```
if file in in-memory-cache then
  return in-memory-cache[file]
else if file in kv
  return kv[file]
else 
  bundle assets 
  store assets in in-memory-cache
  return in-memory-cache[file]
  store assets in kv in background
  housekeep stale assets in background
```

With this algorithm, we ensure:
1. Any isolate is able to serve the website without relying on KV. 
2. If an asset is inside kv, any isolate is able to return it
3. KV is bounded by housekeeping stale assets

`2` is nice because it should remove issues of missing assets when any chunk changes due to esm.sh changes

### Consistency
`store assets in kv in background` means:

1. Files are split into 64Kb chunks and saved in KV in a kv transaction. This ensures the file is stored consistently on KV
2. chunks are stored before islands and entrypoints. This ensures that if an island is served, it's corresponding chunks are retrievable from KV. This ensures no more issues with missing assets when serving the store

> Note that KV currently has a limit of 10 operations in a transaction. If your asset is bigger than `10 * 64Kb`, it will fail saving on KV, but it's ok since the isolates work without KV

### Streaming
A nice approach to saving assets in KV in 64Kb chunks is that we are able to stream these chunks when serving assets from KV

### Debug
Since this is a difficult feature to get right, I'm adding a bunch of console.logs that may be removed in the future. To make your life more pleasant, I added emojis! 🎉 

I hope to make this PR a fresh PR one day. 